### PR TITLE
Add support for stable suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 ## Supported Checks
 
+- FileEndsInNewLine
 - [IfChangedThenChange/IfThisThenThat](presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/checks/IfChangeThenChangeChecker.md)
+- [KeepSorted](presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/fixes/KeepSorted.md)

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/fixes/KeepSorted.md
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/fixes/KeepSorted.md
@@ -11,4 +11,54 @@ Known Differences:
 
 - `numeric=yes` is limited to numbers with 100 digits
 - Support for a `template` option for pre-defined sets of options. Useful when needing to re-use the
-  same options across many files.
+  same options across many files. Templates are specified in the `KeepSorted` initialization.
+- Support for a `maintain_suffix_order` post processor which takes a regex with 1 to 2 groups. The
+  first match group is sticky to the sorted group position, while the second match group is sticky
+  to the sorted group item itself. For example `maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))`
+  would keep commas in a consistent position. Using this option disables the default comma-handling
+  behavior that Google's implementation has.
+
+  <table border="0">
+  <tr>
+  <td>
+  
+  ```
+  a = [
+
+    1,
+    3, // three
+    2
+  
+  ]
+  b = [
+
+    1,
+    3,
+    2 // two
+
+  ]
+  ```
+  
+  </td>
+  <td>
+  
+  ```diff
+   a = [
+  +  // keep-sorted start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
+     1,
+     2,
+     3 // three
+  +  // keep-sorted end
+   ]
+   b = [
+  +  // keep-sorted start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
+     1,
+     2, // two
+     3
+  +  // keep-sorted end
+   ]
+  ```
+  
+  </td>
+  </tr>
+  </table>

--- a/presubmitchecks-core/src/test/kotlin/org/undermined/presubmitchecks/fixes/KeepSortedTest.kt
+++ b/presubmitchecks-core/src/test/kotlin/org/undermined/presubmitchecks/fixes/KeepSortedTest.kt
@@ -651,6 +651,66 @@ class KeepSortedTest {
         )
     }
 
+    @Test
+    fun testMaintainSuffix() {
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        keepSorted.checkSorted(
+            config,
+            """
+            // keep-sorted start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
+            C, // bob
+            C, /* haha */
+            1,
+            D
+              D, // :)
+            B,
+            B, // lol
+            1,
+            A
+            // keep-sorted end
+            """.trimIndent(),
+            """
+            // keep-sorted start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
+            1,
+            A,
+            B,
+            B, // lol
+            C, /* haha */
+            C, // bob
+            D
+              D // :)
+            // keep-sorted end
+            """.trimIndent()
+        )
+        keepSorted.checkSorted(
+            config,
+            """
+            // keep-sorted start
+            1,
+            3, // three
+            2
+            // keep-sorted end
+            // keep-sorted start
+            1,
+            3,
+            2 // two
+            // keep-sorted end
+            """.trimIndent(),
+            """
+            // keep-sorted start
+            1,
+            2
+            3, // three
+            // keep-sorted end
+            // keep-sorted start
+            1,
+            2 // two,
+            3
+            // keep-sorted end
+            """.trimIndent()
+        )
+    }
+
     @ParameterizedTest
     @ValueSource(strings = [
         "block",


### PR DESCRIPTION
This generalizes comma handling and allows it to handle comments.

Previously we would allow bubbling any common (except for 1 sorted group) suffix up. We now limit it to a single char, defaulting to `,` (comma) to match Google's behavior. This doesn't handle trailing comments well so we introduce a more general mechanism that replaces this behavior that allows making a subset of a suffix sticky to the position of the group. 