### PR TITLE
Implement new file visitor

### DIFF
--- a/.github/presubmitchecks.json
+++ b/.github/presubmitchecks.json
@@ -1,9 +1,12 @@
 {
   "checkerConfigs": {
+    "FileEndsInNewLine": {
+      "severity": "ERROR"
+    },
     "IfChangeThenChange": {
       "severity": "WARNING"
     },
-    "FileEndsInNewLine": {
+    "KeepSorted": {
       "severity": "ERROR"
     }
   }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,12 +4,18 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   checks:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -19,10 +25,27 @@ jobs:
         with:
           cache-read-only: false
           cache-encryption-key: ${{ secrets.GradleEncryptionKey }}
-      - run: ./gradlew check
-        shell: bash
       - name: Run Presubmit Checks
         uses: './'
+        id: presubmitchecks
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/presubmitchecks.json
+          apply-fixes: "true"
+      - run: ./gradlew check
+        shell: bash
+
+#      - name: Commit Fixes
+#        if: false && steps.presubmitchecks.outputs.applied-fixes == '1'
+#        run: |
+#          git config user.name "github-actions[bot]"
+#          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+#          git add .
+#          git commit -m "Presubmit Fixes"
+#          git push
+#        shell: bash
+#      - uses: parkerbxyz/suggest-changes@v1
+#        if: steps.presubmitchecks.outputs.applied-fixes == '1'
+#        with:
+#          comment: 'Please commit the suggested changes.'
+#          event: 'COMMENT'

--- a/README.md
+++ b/README.md
@@ -5,3 +5,97 @@
 - FileEndsInNewLine
 - [IfChangedThenChange/IfThisThenThat](presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/checks/IfChangeThenChangeChecker.md)
 - [KeepSorted](presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/fixes/KeepSorted.md)
+
+## Usage
+
+### Git Pre-Commit
+
+```shell
+./gradlew :presubmitchecks-cli:installDist && git diff main | ./presubmitchecks-cli/build/install/presubmitchecks-cli/bin/presubmitchecks-cli git-pre-commit --diff - --fix
+```
+
+### GitHub Action
+
+Add it to your PR workflow using:
+
+```yaml
+    steps:
+      - name: Run Presubmit Checks
+        uses: 'AlexanderGH/presubmitchecks'
+        id: presubmitchecks
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+To automatically suggest fixes:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run Presubmit Checks
+        uses: 'AlexanderGH/presubmitchecks'
+        id: presubmitchecks
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/presubmitchecks.json
+          apply-fixes: "true"
+      - uses: parkerbxyz/suggest-changes@v1
+        if: steps.presubmitchecks.outputs.applied-fixes == '1'
+        with:
+          comment: 'Please commit the suggested changes.'
+          event: 'COMMENT'
+```
+
+Or to automatically push fixes:
+
+```yaml
+name: Check PR
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run Presubmit Checks
+        uses: 'AlexanderGH/presubmitchecks'
+        id: presubmitchecks
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/presubmitchecks.json
+          apply-fixes: "true"
+      - name: Commit Fixes
+        if: steps.presubmitchecks.outputs.applied-fixes == '1'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Presubmit Fixes"
+          git push
+        shell: bash
+```
+
+## Configuration

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,14 @@ inputs:
   config-file:
     description: Path to the presubmit checks config file.
     required: false
+  apply-fixes:
+    description: Applies fixes automatically.
+    required: false
+    default: "false"
+outputs:
+  applied-fixes:
+    description: "Set to 1 if fixes were applied"
+    value: ${{ steps.presubmitchecks.outputs.APPLIED_FIXES }}
 
 runs:
   using: "composite"
@@ -24,6 +32,8 @@ runs:
       shell: bash
     - run: $GITHUB_ACTION_PATH/presubmitchecks-cli/build/install/presubmitchecks-cli/bin/presubmitchecks-cli github-action
       shell: bash
+      id: presubmitchecks
       env:
         GITHUB_REPO_TOKEN: ${{ inputs.repo-token }}
         INPUT_CONFIG_FILE: ${{ inputs.config-file }}
+        INPUT_APPLY_FIXES: ${{ inputs.apply-fixes }}

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/checks/IfChangeThenChangeChecker.md
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/checks/IfChangeThenChangeChecker.md
@@ -11,6 +11,10 @@ the current file) and an  optional label (if absent: the entire file), though at
 specified. Blocks may be nested, but start and end directives must be balanced.
 
 ```
+// Special syntax to disable procesing this lint in the rest of the file.
+// Useful for using the check string in things like documentation.
+// LINT.IfChange(@ignore)
+
 // Anonymous Block
 LINT.IfChange
 // Labeled Block
@@ -24,10 +28,10 @@ LINT.ThenChange(relative/path/to/file.txt)
 // Any change in the other file fulfills the requirement.
 LINT.ThenChange(//from/repo/root/file.txt)
 // A block in the same file.
-// Only changes in in that block fulfill the requirement.
+// Only changes in a block name "other-block-name" in the same file fulfill the requirement.
 LINT.ThenChange(:other-block-name)
 // You can also combine the two.
-// Only changes in a block names "other-block-name" in that file.txt fulfill the requirement.
+// Only changes in a block named "other-block-name" in file.txt fulfill the requirement.
 LINT.ThenChange(file.txt:other-block-name)
 ```
 

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/checks/KeepSortedChecker.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/checks/KeepSortedChecker.kt
@@ -1,0 +1,123 @@
+package org.undermined.presubmitchecks.checks
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import org.undermined.presubmitchecks.core.Changelist
+import org.undermined.presubmitchecks.core.ChangelistVisitor
+import org.undermined.presubmitchecks.core.CheckResultFix
+import org.undermined.presubmitchecks.core.CheckResultMessage
+import org.undermined.presubmitchecks.core.Checker
+import org.undermined.presubmitchecks.core.CheckerChangelistVisitorFactory
+import org.undermined.presubmitchecks.core.CheckerProvider
+import org.undermined.presubmitchecks.core.CheckerReporter
+import org.undermined.presubmitchecks.core.CoreConfig
+import org.undermined.presubmitchecks.core.FileVisitors
+import org.undermined.presubmitchecks.core.Repository
+import org.undermined.presubmitchecks.core.toResultSeverity
+import org.undermined.presubmitchecks.fixes.Fixes
+import org.undermined.presubmitchecks.fixes.Fixes.transformLines
+import org.undermined.presubmitchecks.fixes.KeepSorted
+import org.undermined.presubmitchecks.fixes.KeepSortedConfig
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+class KeepSortedChecker(
+    override val config: CoreConfig,
+) :
+    Checker,
+    CheckerChangelistVisitorFactory {
+    override fun newCheckVisitor(
+        repository: Repository,
+        changelist: Changelist,
+        reporter: CheckerReporter
+    ): Optional<ChangelistVisitor> {
+        return Optional.of(object :
+            ChangelistVisitor,
+            ChangelistVisitor.FileVisitor,
+            //ChangelistVisitor.FileVisitor.FileAfterLineVisitor,
+            ChangelistVisitor.FileVisitor.FileAfterSequentialVisitor {
+
+            override fun enterFile(file: Changelist.FileOperation): Boolean {
+                return file.isText && file !is Changelist.FileOperation.RemovedFile
+            }
+
+            fun visitAfterLine(name: String, line: FileVisitors.FileLine): Boolean {
+                if (line.content.contains("keep-sorted ")) {
+                    reporter.report(
+                        CheckResultFix(
+                            fixId = ID,
+                            file = name,
+                            transform = ::autoFix,
+                        )
+                    )
+                }
+                return true
+            }
+
+            override suspend fun visitAfterFile(name: String, inputStream: InputStream) {
+                val changed = AtomicInteger()
+                val keepSorted = KeepSorted()
+                Fixes.didLinesChange(inputStream.bufferedReader().lineSequence(), changed) {
+                    yieldAll(keepSorted.sort(
+                        config = KeepSortedConfig(
+                            matchRegexp = KeepSortedConfig.pattern("kt")
+                        ),
+                        lines = it,
+                    ))
+                }.count()
+                if (changed.get() != -1) {
+                    reporter.report(
+                        CheckResultMessage(
+                            checkGroupId = ID,
+                            title = "Not Sorted",
+                            message = "This section should be kept sorted.",
+                            severity = config.severity.toResultSeverity(),
+                            location = CheckResultMessage.Location(
+                                file = name,
+                                startLine = changed.get(),
+                            ),
+                            fix = CheckResultFix(
+                                fixId = ID,
+                                file = name,
+                                transform = ::autoFix,
+                            )
+                        )
+                    )
+                }
+            }
+        })
+    }
+
+    fun autoFix(inputStream: InputStream, outputStream: OutputStream): Boolean {
+       return inputStream.transformLines(outputStream) {
+           val keepSorted = KeepSorted()
+           val sorted = keepSorted.sort(
+               config = KeepSortedConfig(
+                   matchRegexp = KeepSortedConfig.pattern("kt")
+               ),
+               lines = it
+           )
+           yieldAll(sorted)
+       }
+    }
+
+    companion object {
+        const val ID = "KeepSorted"
+
+        val PROVIDER = object : CheckerProvider {
+            override val id: String = ID
+
+            override fun newChecker(
+                config: JsonElement,
+            ): KeepSortedChecker {
+                return KeepSortedChecker(
+                    config = Json.decodeFromJsonElement(config),
+                )
+            }
+        }
+    }
+}

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/Changelist.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/Changelist.kt
@@ -4,7 +4,6 @@ data class Changelist(
     val title: String,
     val description: String,
     val files: Collection<FileOperation>,
-    val patchOnly: Boolean,
 ) {
     val tags: Map<String, String> by lazy {
         val tagRegex = """([A-Za-z0-9_]+)(?:=|: )(.*?)""".toRegex()
@@ -18,19 +17,21 @@ data class Changelist(
 
     sealed interface FileOperation {
         val name: String
+        val isBinary: Boolean
+        val isText: Boolean get() = !isBinary
 
         data class AddedFile(
             override val name: String,
             val patchLines: Collection<PatchLine>,
             val afterRef: String,
-            val afterRevision: FileContents,
+            override val isBinary: Boolean,
         ) : FileOperation
 
         data class RemovedFile(
             override val name: String,
             val patchLines: Collection<PatchLine>,
             val beforeRef: String,
-            val beforeRevision: FileContents,
+            override val isBinary: Boolean,
         ) : FileOperation
 
         data class ModifiedFile(
@@ -39,8 +40,7 @@ data class Changelist(
             val patchLines: Collection<PatchLine>,
             val beforeRef: String,
             val afterRef: String,
-            val afterRevision: FileContents,
-            val beforeRevision: FileContents = afterRevision.reversePatch(patchLines),
+            override val isBinary: Boolean,
         ) : FileOperation
     }
 
@@ -54,5 +54,6 @@ data class Changelist(
     enum class ChangeOperation {
         ADDED,
         REMOVED,
+        CONTEXT
     }
 }

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/ChangelistVisitor.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/ChangelistVisitor.kt
@@ -1,82 +1,147 @@
 package org.undermined.presubmitchecks.core
 
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileAfterLineVisitor
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileAfterRandomVisitor
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileAfterSequentialVisitor
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileBeforeLineVisitor
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileBeforeRandomVisitor
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileBeforeSequentialVisitor
+import java.io.InputStream
+import java.nio.ByteBuffer
+
 interface ChangelistVisitor {
     fun enterChangelist(changelist: Changelist): Boolean { return true }
 
-    fun enterFile(file: Changelist.FileOperation): Boolean { return true }
-
-    fun visitChangedLine(operation: Changelist.ChangeOperation, line: Int, content: String) {}
-
-    fun leaveFile(file: Changelist.FileOperation) {}
-
     fun leaveChangelist(changelist: Changelist) {}
 
-    interface FileBeforeVisitor {
-        fun visitBeforeLine(line: Int, content: String, modified: Boolean)
-    }
+    interface FileVisitor {
 
-    interface FileAfterVisitor {
-        fun visitAfterLine(line: Int, content: String, modified: Boolean)
+        fun enterFile(file: Changelist.FileOperation): Boolean { return true }
+
+        fun leaveFile(file: Changelist.FileOperation) {}
+
+        interface FileDeltaLineVisitor {
+            fun visitChangedLine(name: String, line: Changelist.PatchLine)
+        }
+
+        interface FileAfterLineVisitor {
+            fun visitAfterLine(name: String, line: FileVisitors.FileLine): Boolean
+        }
+        interface FileAfterSequentialVisitor {
+            suspend fun visitAfterFile(name: String, inputStream: InputStream)
+        }
+        interface FileAfterRandomVisitor {
+            suspend fun visitAfterFile(name: String, byteBuffer: ByteBuffer)
+        }
+
+        interface FileBeforeLineVisitor {
+            fun visitBeforeLine(name: String, line: FileVisitors.FileLine): Boolean
+        }
+        interface FileBeforeSequentialVisitor {
+            suspend fun visitBeforeFile(name: String, inputStream: InputStream)
+        }
+        interface FileBeforeRandomVisitor {
+            suspend fun visitBeforeFile(name: String, byteBuffer: ByteBuffer)
+        }
     }
 }
 
-suspend fun Changelist.visit(visitors: Collection<ChangelistVisitor>) {
+suspend fun Changelist.visit(repository: Repository, visitors: Collection<ChangelistVisitor>) {
     val changelist = this
-    val changelistVisitors = visitors.filter { it.enterChangelist(changelist) }
+    val changelistVisitors = visitors.filter {
+        it.enterChangelist(changelist)
+    }
 
     changelist.files.forEach { file ->
-        val fileVisitors = changelistVisitors.filter { it.enterFile(file) }
+        val fileVisitors = changelistVisitors
+            .filterIsInstance<ChangelistVisitor.FileVisitor>()
+            .filter{
+                it.enterFile(file)
+            }
 
-        when (file) {
-            is Changelist.FileOperation.AddedFile -> {
-                (file.afterRevision as? FileContents.Text)?.lines?.invoke()?.forEachIndexed { i, content ->
-                    fileVisitors.forEach {
-                        it.visitChangedLine(Changelist.ChangeOperation.ADDED, i + 1, content)
-                        (it as? ChangelistVisitor.FileAfterVisitor)?.visitAfterLine(i + 1, content, true)
-                    }
+        val deltaVisitors = fileVisitors
+            .filterIsInstance<ChangelistVisitor.FileVisitor.FileDeltaLineVisitor>()
+
+        if (deltaVisitors.isNotEmpty()) {
+            when (file) {
+                is Changelist.FileOperation.AddedFile -> file.patchLines
+                is Changelist.FileOperation.RemovedFile -> file.patchLines
+                is Changelist.FileOperation.ModifiedFile -> file.patchLines
+            }.forEach { patchLine ->
+                deltaVisitors.forEach {
+                    it.visitChangedLine(file.name, patchLine)
                 }
             }
-            is Changelist.FileOperation.RemovedFile -> {
-                (file.beforeRevision as? FileContents.Text)?.lines?.invoke()?.forEachIndexed { i, content ->
-                    fileVisitors.forEach {
-                        it.visitChangedLine(Changelist.ChangeOperation.REMOVED, i + 1, content)
-                        (it as? ChangelistVisitor.FileBeforeVisitor)?.visitBeforeLine(i + 1, content, true)
-                    }
-                }
-            }
-            is Changelist.FileOperation.ModifiedFile -> {
-                fileVisitors.filterIsInstance<ChangelistVisitor.FileBeforeVisitor>().let { fileBeforeVisitors ->
-                    if (fileBeforeVisitors.isNotEmpty()) {
-                        val modifiedLines = file.patchLines
-                            .filter { it.operation == Changelist.ChangeOperation.REMOVED }
-                            .map { it.line }
-                            .toSet()
-                        (file.beforeRevision as? FileContents.Text)?.lines?.invoke()?.forEachIndexed { i, content ->
-                            fileBeforeVisitors.forEach { fileBeforeVisitor ->
-                                fileBeforeVisitor.visitBeforeLine(i + 1, content, modifiedLines.contains(i + 1))
-                            }
-                        }
-                    }
-                }
-                file.patchLines.forEach { patchLine ->
-                    fileVisitors.forEach {
-                        it.visitChangedLine(patchLine.operation, patchLine.line, patchLine.content)
-                    }
-                }
-                fileVisitors.filterIsInstance<ChangelistVisitor.FileAfterVisitor>().let { fileAfterVisitors ->
-                    if (fileAfterVisitors.isNotEmpty()) {
+        }
+
+        if (file !is Changelist.FileOperation.RemovedFile) {
+            FileVisitors.visitFile(
+                {
+                    repository.readFile(file.name, when (file) {
+                        is Changelist.FileOperation.AddedFile -> file.afterRef
+                        is Changelist.FileOperation.ModifiedFile -> file.afterRef
+                        else -> TODO()
+                    })
+                },
+                lineVisitors = fileVisitors
+                    .filterIsInstance<FileAfterLineVisitor>().map { v ->
+                        { v.visitAfterLine(file.name, it) }
+                    },
+                rawFileVisitorsSequential = fileVisitors
+                    .filterIsInstance<FileAfterSequentialVisitor>().map { v ->
+                        { v.visitAfterFile(file.name, it) }
+                    },
+                rawFileVisitorsRandom = fileVisitors
+                    .filterIsInstance<FileAfterRandomVisitor>().map { v ->
+                        { v.visitAfterFile(file.name, it) }
+                    },
+                isLineModified = when (file) {
+                    is Changelist.FileOperation.ModifiedFile -> {
                         val modifiedLines = file.patchLines
                             .filter { it.operation == Changelist.ChangeOperation.ADDED }
                             .map { it.line }
                             .toSet()
-                        (file.afterRevision as? FileContents.Text)?.lines?.invoke()?.forEachIndexed { i, content ->
-                            fileAfterVisitors.forEach { fileBeforeVisitor ->
-                                fileBeforeVisitor.visitAfterLine(i + 1, content, modifiedLines.contains(i + 1))
-                            }
-                        }
+                        fun (line: Int): Boolean { return modifiedLines.contains(line) }
                     }
+                    is Changelist.FileOperation.AddedFile -> fun (_): Boolean { return true }
+                    else -> TODO()
                 }
-            }
+            )
+        }
+
+        if (file !is Changelist.FileOperation.AddedFile) {
+            FileVisitors.visitFile(
+                {
+                    repository.readFile(file.name, when (file) {
+                        is Changelist.FileOperation.RemovedFile -> file.beforeRef
+                        is Changelist.FileOperation.ModifiedFile -> file.beforeRef
+                        else -> TODO()
+                    })
+                },
+                lineVisitors = fileVisitors
+                    .filterIsInstance<FileBeforeLineVisitor>().map { v ->
+                        { v.visitBeforeLine(file.name, it) }
+                    },
+                rawFileVisitorsSequential = fileVisitors
+                    .filterIsInstance<FileBeforeSequentialVisitor>().map { v ->
+                        { v.visitBeforeFile(file.name, it) }
+                    },
+                rawFileVisitorsRandom = fileVisitors
+                    .filterIsInstance<FileBeforeRandomVisitor>().map { v ->
+                        { v.visitBeforeFile(file.name, it) }
+                    },
+                isLineModified = when (file) {
+                    is Changelist.FileOperation.ModifiedFile -> {
+                        val modifiedLines = file.patchLines
+                            .filter { it.operation == Changelist.ChangeOperation.REMOVED }
+                            .map { it.line }
+                            .toSet()
+                        fun (line: Int): Boolean { return modifiedLines.contains(line) }
+                    }
+                    is Changelist.FileOperation.RemovedFile -> fun (_): Boolean { return true }
+                    else -> TODO()
+                }
+            )
         }
 
         fileVisitors.forEach { it.leaveFile(file) }

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/CheckerRegistry.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/CheckerRegistry.kt
@@ -4,10 +4,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromStream
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import org.undermined.presubmitchecks.checks.FileEndsInNewLineChecker
 import org.undermined.presubmitchecks.checks.IfChangeThenChangeChecker
+import org.undermined.presubmitchecks.checks.KeepSortedChecker
 
 class CheckerRegistry {
     companion object {
@@ -15,6 +14,7 @@ class CheckerRegistry {
             // keep-sorted start
             FileEndsInNewLineChecker.PROVIDER,
             IfChangeThenChangeChecker.PROVIDER,
+            KeepSortedChecker.PROVIDER,
             // keep-sorted end
         ).associateBy { it.id }
 
@@ -43,6 +43,19 @@ class CheckerService(
 
     @Serializable
     data class GlobalConfig(
+        val textFiles: List<String> = listOf(
+            // keep-sorted start
+            ".java",
+            ".json",
+            ".kt",
+            ".kts",
+            ".md",
+            ".txt",
+            ".yaml",
+            ".yml",
+            // keep-sorted end
+        ),
+
         val checkerConfigs: Map<String, JsonElement> = emptyMap()
     )
 }

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/FileCollection.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/FileCollection.kt
@@ -1,0 +1,77 @@
+package org.undermined.presubmitchecks.core
+
+import org.undermined.presubmitchecks.core.Changelist.FileOperation
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileAfterLineVisitor
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileAfterRandomVisitor
+import org.undermined.presubmitchecks.core.ChangelistVisitor.FileVisitor.FileAfterSequentialVisitor
+import java.util.Optional
+
+data class FileCollection(
+    val files: Collection<FileOperation.AddedFile>,
+)
+
+suspend fun FileCollection.visit(
+    repository: Repository, visitors:
+    Collection<ChangelistVisitor.FileVisitor>,
+) {
+    val changelist = this
+
+    changelist.files.forEach { file ->
+        val fileVisitors = visitors
+            .filter{
+                it.enterFile(file)
+            }
+
+            FileVisitors.visitFile(
+                {
+                    repository.readFile(file.name, file.afterRef)
+                },
+                lineVisitors = fileVisitors
+                    .filterIsInstance<FileAfterLineVisitor>().map { v ->
+                        { v.visitAfterLine(file.name, it) }
+                    },
+                rawFileVisitorsSequential = fileVisitors
+                    .filterIsInstance<FileAfterSequentialVisitor>().map { v ->
+                        { v.visitAfterFile(file.name, it) }
+                    },
+                rawFileVisitorsRandom = fileVisitors
+                    .filterIsInstance<FileAfterRandomVisitor>().map { v ->
+                        { v.visitAfterFile(file.name, it) }
+                    },
+                isLineModified = fun (_): Boolean { return true },
+            )
+
+        fileVisitors.forEach { it.leaveFile(file) }
+    }
+}
+
+interface CheckerFileCollectionVisitorFactory {
+    fun newCheckVisitor(
+        repository: Repository,
+        fileCollection: FileCollection,
+        reporter: CheckerReporter,
+    ): Optional<ChangelistVisitor.FileVisitor>
+}
+
+suspend fun CheckerService.runChecks(
+    repository: Repository,
+    files: Iterable<String>,
+    reporter: CheckerReporter
+) {
+    val fc = FileCollection(files.map { file ->
+        FileOperation.AddedFile(
+            file,
+            patchLines = emptyList(),
+            afterRef = "",
+            isBinary = false
+        )
+    })
+    checkers.values.filterIsInstance<CheckerFileCollectionVisitorFactory>().map {
+        it.newCheckVisitor(repository, fc, reporter = reporter)
+    }
+        .filter { it.isPresent }
+        .map { it.get() }
+        .takeIf { it.isNotEmpty() }?.let {
+            fc.visit(repository, it)
+        }
+}

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/FileContents.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/FileContents.kt
@@ -1,9 +1,0 @@
-package org.undermined.presubmitchecks.core
-
-import java.io.InputStream
-
-sealed interface FileContents {
-    data class Binary(val stream: suspend () -> InputStream): FileContents
-
-    data class Text(val lines: suspend () -> Sequence<String>): FileContents
-}

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/FileVisitors.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/FileVisitors.kt
@@ -1,0 +1,145 @@
+package org.undermined.presubmitchecks.core
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+
+object FileVisitors {
+    suspend fun visitFile(
+        inputStreamProvider: suspend () -> InputStream,
+        lineVisitors: Collection<(FileLine) -> Boolean> = emptyList(),
+        rawFileVisitorsSequential: Collection<suspend (InputStream) -> Unit> = emptyList(),
+        rawFileVisitorsRandom: Collection<suspend (ByteBuffer) -> Unit> = emptyList(),
+        isLineModified: (Int) -> Boolean = { false }
+    ) {
+        if (lineVisitors.isEmpty()
+            && rawFileVisitorsSequential.isEmpty()
+            && rawFileVisitorsRandom.isEmpty()) {
+            return
+        }
+
+        lateinit var bb: ByteBuffer
+        if (
+            rawFileVisitorsRandom.isNotEmpty()
+            || rawFileVisitorsSequential.size + (if (lineVisitors.isEmpty()) 0 else 1) > 1
+        ) {
+            val byteArrayOutputStream = java.io.ByteArrayOutputStream()
+            val buffer = ByteArray(4096)
+            var bytesRead: Int
+
+            val inputStream = inputStreamProvider.invoke()
+            while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                byteArrayOutputStream.write(buffer, 0, bytesRead)
+            }
+            inputStream.close()
+
+            bb = ByteBuffer.wrap(byteArrayOutputStream.toByteArray()).asReadOnlyBuffer()
+            object : InputStream() {
+                override fun read(): Int {
+                    return if (bb.hasRemaining()) {
+                        bb.get().toInt() and 0xFF //Read byte as unsigned int
+                    } else {
+                        -1 // End of stream
+                    }
+                }
+
+                override fun read(b: ByteArray, off: Int, len: Int): Int {
+                    if (!bb.hasRemaining()) {
+                        return -1
+                    }
+
+                    val actualLen = minOf(len, bb.remaining()) // Don't read past buffer limit
+                    bb.get(b, off, actualLen)
+                    return actualLen
+                }
+
+                override fun available(): Int = bb.remaining()
+            }
+        } else {
+            inputStreamProvider.invoke()
+        }.use { inputStream ->
+            if (lineVisitors.isNotEmpty()) {
+                val lineVisitorsLocal = mutableListOf<((FileLine) -> Boolean)?>().apply {
+                    addAll(lineVisitors)
+                }
+                val buffer = ByteArray(4096)
+                val currentLine = StringBuilder()
+                var previousCharWasCR = false
+                val fileLine = FileLine()
+                var shouldContinue = true
+
+                fun processLine(
+                    content: String,
+                    nl: Boolean
+                ) {
+                    fileLine.content = content
+                    fileLine.line++
+                    fileLine.nl = nl
+                    fileLine.isModified = isLineModified(fileLine.line)
+
+                    shouldContinue = false
+                    lineVisitorsLocal.forEachIndexed { index, function ->
+                        if (function != null) {
+                            if (!function.invoke(fileLine)) {
+                                lineVisitorsLocal[index] = null
+                            } else {
+                                shouldContinue = true
+                            }
+                        }
+                    }
+                }
+
+                while (shouldContinue) {
+                    val bytesRead = inputStream.read(buffer)
+                    if (bytesRead == -1) {
+                        if (currentLine.isNotEmpty()) {
+                            processLine(currentLine.toString(), false)
+                        }
+                        break
+                    }
+
+                    for (i in 0 until bytesRead) {
+                        val char = buffer[i].toInt().toChar()
+
+                        if (previousCharWasCR && char == '\n') {
+                            processLine(currentLine.toString(), true)
+                            currentLine.clear()
+                            previousCharWasCR = false
+                        } else if (char == '\n') {
+                            processLine(currentLine.toString(), true)
+                            currentLine.clear()
+                            previousCharWasCR = false
+                        } else if (char == '\r') {
+                            previousCharWasCR = true
+                        } else {
+                            if (previousCharWasCR) {
+                                processLine(currentLine.toString(), true)
+                                currentLine.clear()
+                                previousCharWasCR = false
+                            }
+                            currentLine.append(char)
+                        }
+                    }
+                }
+            }
+            rawFileVisitorsSequential.forEach {
+                bb.rewind()
+                it.invoke(inputStream)
+            }
+            rawFileVisitorsRandom.forEach {
+                bb.rewind()
+                it.invoke(bb)
+            }
+        }
+    }
+
+    class FileLine {
+        var content: String = ""
+            internal set
+        var line: Int = 0
+            internal set
+        var nl: Boolean = false
+            internal set
+        var isModified: Boolean = false
+            internal set
+    }
+}

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/Patches.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/Patches.kt
@@ -2,53 +2,48 @@ package org.undermined.presubmitchecks.core
 
 import org.undermined.presubmitchecks.core.Changelist.PatchLine
 
-internal fun FileContents.reversePatch(patchLines: Collection<PatchLine>): FileContents {
-    check(this is FileContents.Text)
-    return FileContents.Text(
-        suspend {
-            val lines = this@reversePatch.lines()
+internal fun Sequence<String>.reversePatch(patchLines: Collection<PatchLine>): Sequence<String> {
+    val lines = this
+    return sequence {
+        var currentLineNumber = 1
+        var operationIndex = 0
+        var skip = 0
 
-            sequence {
-                var currentLineNumber = 1
-                var operationIndex = 0
-                var skip = 0
-
-                val patchLinesList = patchLines.toList()
-                for (newLine in lines) {
-                    while (
-                        operationIndex < patchLinesList.size
-                        && patchLinesList[operationIndex].line <= currentLineNumber
-                    ) {
-                        val operation = patchLinesList[operationIndex]
-                        when (operation.operation) {
-                            Changelist.ChangeOperation.ADDED -> {
-                                skip++
-                            }
-
-                            Changelist.ChangeOperation.REMOVED -> {
-                                yield(operation.content)
-                                currentLineNumber++
-                            }
-                        }
-                        operationIndex++
+        val patchLinesList = patchLines.toList()
+        for (newLine in lines) {
+            while (
+                operationIndex < patchLinesList.size
+                && patchLinesList[operationIndex].line <= currentLineNumber
+            ) {
+                val operation = patchLinesList[operationIndex]
+                when (operation.operation) {
+                    Changelist.ChangeOperation.CONTEXT -> {}
+                    Changelist.ChangeOperation.ADDED -> {
+                        skip++
                     }
-                    if (skip > 0) {
-                        skip--
-                    } else {
-                        yield(newLine)
+
+                    Changelist.ChangeOperation.REMOVED -> {
+                        yield(operation.content)
                         currentLineNumber++
                     }
                 }
-
-                // Process remaining additions after the last new line
-                while (operationIndex < patchLinesList.size) {
-                    val operation = patchLinesList[operationIndex]
-                    if (operation.operation == Changelist.ChangeOperation.ADDED) {
-                        yield(operation.content)
-                    }
-                    operationIndex++
-                }
+                operationIndex++
+            }
+            if (skip > 0) {
+                skip--
+            } else {
+                yield(newLine)
+                currentLineNumber++
             }
         }
-    )
+
+        // Process remaining additions after the last new line
+        while (operationIndex < patchLinesList.size) {
+            val operation = patchLinesList[operationIndex]
+            if (operation.operation == Changelist.ChangeOperation.ADDED) {
+                yield(operation.content)
+            }
+            operationIndex++
+        }
+    }
 }

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/Repository.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/core/Repository.kt
@@ -1,5 +1,7 @@
 package org.undermined.presubmitchecks.core
 
+import java.io.File
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -8,5 +10,27 @@ interface Repository {
 
     interface WritableRepository {
         suspend fun writeFile(path: String, writer: (OutputStream) -> Unit)
+    }
+}
+
+class LocalFilesystemRepository(
+    private val rootPath: File,
+) : Repository, Repository.WritableRepository {
+
+    override suspend fun readFile(path: String, ref: String): InputStream {
+        check(ref == "")
+        return File(rootPath, path).inputStream().buffered()
+    }
+
+    override suspend fun writeFile(path: String, writer: (OutputStream) -> Unit) {
+        val targetFile = File(rootPath, path).absoluteFile
+        val tmpFile = File.createTempFile(targetFile.name, ".tmp", targetFile.parentFile)
+        tmpFile.outputStream().use {
+            writer(it)
+        }
+        if (!tmpFile.renameTo(targetFile)) {
+            tmpFile.delete()
+            throw IOException("Could not write: $path")
+        }
     }
 }

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/fixes/Fixes.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/fixes/Fixes.kt
@@ -5,6 +5,7 @@ import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 typealias FileFixFilter = (InputStream, OutputStream) -> Boolean
 
@@ -13,7 +14,7 @@ object Fixes {
     fun chainStreamModifiers(modifiers: List<FileFixFilter>): FileFixFilter {
         return { inputStream, outputStream ->
             var currentInputStream = inputStream
-            val isDifferent = AtomicBoolean()
+            val isDifferent = AtomicBoolean(false)
 
             val threads = modifiers.map { modifier ->
                 val pipedOutputStream = PipedOutputStream()
@@ -21,10 +22,13 @@ object Fixes {
 
                 val thisInput = currentInputStream
                 Thread {
-                    if (modifier(thisInput, pipedOutputStream)) {
-                        isDifferent.set(true)
+                    try {
+                        if (modifier(thisInput, pipedOutputStream)) {
+                            isDifferent.set(true)
+                        }
+                    } finally {
+                        pipedOutputStream.close()
                     }
-                    pipedOutputStream.close()
                 }.also {
                     currentInputStream = pipedInputStream
                 }
@@ -37,5 +41,79 @@ object Fixes {
 
             isDifferent.get()
         }
+    }
+
+    fun didLinesChange(
+        input: Sequence<String>,
+        firstChangedLine: AtomicInteger,
+        transform: suspend SequenceScope<String>.(Sequence<String>) -> Unit
+    ): Sequence<String> {
+        var changed = false
+        val queue = ArrayDeque<String>(32)
+        var line = 0
+        firstChangedLine.set(-1)
+        return sequence {
+            transform(input.onEach {
+                if (!changed) {
+                    queue.addLast(it)
+                }
+            })
+        }.onEach { out ->
+            line++
+            if (!changed && queue.removeFirstOrNull() != out) {
+                changed = true
+                firstChangedLine.set(line)
+                queue.clear()
+            }
+        }
+    }
+
+    fun InputStream.transformLines(
+        outputStream: OutputStream,
+        transform: suspend SequenceScope<String>.(Sequence<String>) -> Unit
+    ): Boolean {
+        val trackedInputStream = TrackingInputStream(this)
+        val inLines = trackedInputStream.bufferedReader().lineSequence()
+        val outWriter = outputStream.writer()
+        val changed = AtomicInteger()
+        didLinesChange(inLines, changed) {
+            this.transform(inLines)
+        }.forEachIndexed { i, out ->
+            if (i != 0) {
+                outWriter.write("\n")
+            }
+            outWriter.write(out)
+        }
+        if (trackedInputStream.getLastByte() == '\n'.code) {
+            outWriter.write("\n")
+        }
+        outWriter.close()
+        return changed.get() != -1
+    }
+
+    private class TrackingInputStream(private val inputStream: InputStream) : InputStream() {
+
+        private var lastByte: Int = -1 // Initialize with -1 to indicate no byte read yet
+
+        fun getLastByte(): Int = lastByte
+
+        override fun read(): Int {
+            val byte = inputStream.read()
+            if (byte != -1) {
+                lastByte = byte // Update lastByte only if a byte was actually read
+            }
+            return byte
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            val bytesRead = inputStream.read(b, off, len)
+            if (bytesRead > 0) {
+                lastByte = b[off + bytesRead - 1].toInt() and 0xFF // Update lastByte with the last byte read
+            }
+            return bytesRead
+        }
+
+        override fun available(): Int = inputStream.available()
+        override fun close() = inputStream.close()
     }
 }

--- a/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/git/GitHubWorkflowCommands.kt
+++ b/presubmitchecks-core/src/main/kotlin/org/undermined/presubmitchecks/git/GitHubWorkflowCommands.kt
@@ -1,6 +1,7 @@
 package org.undermined.presubmitchecks.git
 
 import org.undermined.presubmitchecks.core.CheckResultMessage
+import java.io.File
 
 object GitHubWorkflowCommands {
     fun debug(message: String) {
@@ -40,6 +41,10 @@ object GitHubWorkflowCommands {
         } finally {
             command("endgroup")
         }
+    }
+
+    fun outputVar(key: String, value: String) {
+        File(System.getenv("GITHUB_OUTPUT")).appendText("$key=$value\n")
     }
 
     private fun command(

--- a/presubmitchecks-core/src/main/resources/presubmitchecks.defaults.json
+++ b/presubmitchecks-core/src/main/resources/presubmitchecks.defaults.json
@@ -1,9 +1,12 @@
 {
   "checkerConfigs": {
+    "FileEndsInNewLine": {
+      "severity": "WARNING"
+    },
     "IfChangeThenChange": {
       "severity": "WARNING"
     },
-    "FileEndsInNewLine": {
+    "KeepSorted": {
       "severity": "WARNING"
     }
   }

--- a/presubmitchecks-core/src/test/kotlin/org/undermined/presubmitchecks/fixes/KeepSortedTest.kt
+++ b/presubmitchecks-core/src/test/kotlin/org/undermined/presubmitchecks/fixes/KeepSortedTest.kt
@@ -17,27 +17,27 @@ class KeepSortedTest {
 
     @Test
     fun testBasic() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
                 before
-            // keep-sorted start
+            // keep-sorted-test start
             
             b
             a
             c
-            // keep-sorted end
+            // keep-sorted-test end
             end
             """.trimIndent(),
             """
                 before
-            // keep-sorted start
+            // keep-sorted-test start
             
             a
             b
             c
-            // keep-sorted end
+            // keep-sorted-test end
             end
             """.trimIndent()
         )
@@ -45,85 +45,85 @@ class KeepSortedTest {
 
     @Test
     fun testWhitespace() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start
+            // keep-sorted-test start
                 b
               c
               a
-            // keep-sorted end
+            // keep-sorted-test end
             middle
-            // keep-sorted start
+            // keep-sorted-test start
                 b
             c
             a
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start
+            // keep-sorted-test start
                 b
               a
               c
-            // keep-sorted end
+            // keep-sorted-test end
             middle
-            // keep-sorted start
+            // keep-sorted-test start
                 b
             a
             c
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testStickyComments() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start sticky_comments=no
+            # keep-sorted-test start sticky_comments=no
             # alice
             username: al1
             # bob
             username: bo2
             # charlie
             username: ch3
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start sticky_comments=no
+            # keep-sorted-test start sticky_comments=no
             # alice
             # bob
             # charlie
             username: al1
             username: bo2
             username: ch3
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start sticky_comments=yes
+            # keep-sorted-test start sticky_comments=yes
             # alice
             username: al1
             # bob
             username: bo2
             # charlie
             username: ch3
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start sticky_comments=yes
+            # keep-sorted-test start sticky_comments=yes
             # alice
             username: al1
             # bob
             username: bo2
             # charlie
             username: ch3
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
     }
@@ -131,7 +131,7 @@ class KeepSortedTest {
     @Test
     fun testBlockAndTemplate() {
         val config = KeepSortedConfig(
-            matchRegexp = KeepSortedConfig.pattern("kt"),
+            matchRegexp = KeepSortedConfig.pattern("test"),
             templates = mapOf(
                 "gradle.kts" to KeepSortedSectionConfig(
                     block = true
@@ -141,7 +141,7 @@ class KeepSortedTest {
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start template=gradle.kts
+            // keep-sorted-test start template=gradle.kts
             implementation(b.c) {
                 because("c")
             }
@@ -151,10 +151,10 @@ class KeepSortedTest {
             implementation(a.b) {
                 because("b")
             }
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start template=gradle.kts
+            // keep-sorted-test start template=gradle.kts
             implementation(a.a) {
                 because("a")
             }
@@ -164,130 +164,130 @@ class KeepSortedTest {
             implementation(b.c) {
                 because("c")
             }
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testGroup() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start group=yes
+            // keep-sorted-test start group=yes
             private final Bar bar;
             private final Baz baz =
                 new Baz()
             private final Foo foo;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start group=yes
+            // keep-sorted-test start group=yes
             private final Bar bar;
             private final Baz baz =
                 new Baz()
             private final Foo foo;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start group=no
+            // keep-sorted-test start group=no
             private final Bar bar;
             private final Baz baz =
                 new Baz()
             private final Foo foo;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start group=no
+            // keep-sorted-test start group=no
                 new Baz()
             private final Bar bar;
             private final Baz baz =
             private final Foo foo;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testRemoveDuplicates() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start remove_duplicates=yes
+            # keep-sorted-test start remove_duplicates=yes
             rotation: bar
             rotation: bar
             rotation: baz
             rotation: foo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start remove_duplicates=yes
+            # keep-sorted-test start remove_duplicates=yes
             rotation: bar
             rotation: baz
             rotation: foo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start remove_duplicates=no
+            # keep-sorted-test start remove_duplicates=no
             rotation: bar
             rotation: bar
             rotation: baz
             rotation: foo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start remove_duplicates=no
+            # keep-sorted-test start remove_duplicates=no
             rotation: bar
             rotation: bar
             rotation: baz
             rotation: foo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testNewlineSeparated() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start
+            # keep-sorted-test start
             Apples
             Bananas
             Oranges
             Pineapples
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start
+            # keep-sorted-test start
             Apples
             Bananas
             Oranges
             Pineapples
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start newline_separated=yes
+            # keep-sorted-test start newline_separated=yes
             Apples
             Bananas
             Oranges
             Pineapples
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start newline_separated=yes
+            # keep-sorted-test start newline_separated=yes
             Apples
             
             Bananas
@@ -295,97 +295,97 @@ class KeepSortedTest {
             Oranges
             
             Pineapples
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testSkipLines() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start skip_lines=2
+            # keep-sorted-test start skip_lines=2
             Name    | Value
             ------- | -----
             Charlie | Baz
             Delta   | Qux
             Bravo   | Bar
             Alpha   | Foo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start skip_lines=2
+            # keep-sorted-test start skip_lines=2
             Name    | Value
             ------- | -----
             Alpha   | Foo
             Bravo   | Bar
             Charlie | Baz
             Delta   | Qux
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testCase() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start case=yes
+            # keep-sorted-test start case=yes
             Bravo
             Delta
             Foxtrot
             alpha
             charlie
             echo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start case=yes
+            # keep-sorted-test start case=yes
             Bravo
             Delta
             Foxtrot
             alpha
             charlie
             echo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start case=no
+            # keep-sorted-test start case=no
             Bravo
             Delta
             Foxtrot
             alpha
             charlie
             echo
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start case=no
+            # keep-sorted-test start case=no
             alpha
             Bravo
             charlie
             Delta
             echo
             Foxtrot
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testGroupPrefixes() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start group_prefixes=and,with
+            # keep-sorted-test start group_prefixes=and,with
             spaghetti
             with meatballs
             peanut butter
@@ -393,10 +393,10 @@ class KeepSortedTest {
             hamburger
             with lettuce
             and tomatoes
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start group_prefixes=and,with
+            # keep-sorted-test start group_prefixes=and,with
             hamburger
             with lettuce
             and tomatoes
@@ -404,13 +404,13 @@ class KeepSortedTest {
             and jelly
             spaghetti
             with meatballs
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            # keep-sorted start group_prefixes=["and", "with"]
+            # keep-sorted-test start group_prefixes=["and", "with"]
             spaghetti
             with meatballs
             peanut butter
@@ -418,10 +418,10 @@ class KeepSortedTest {
             hamburger
             with lettuce
             and tomatoes
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent(),
             """
-            # keep-sorted start group_prefixes=["and", "with"]
+            # keep-sorted-test start group_prefixes=["and", "with"]
             hamburger
             with lettuce
             and tomatoes
@@ -429,129 +429,138 @@ class KeepSortedTest {
             and jelly
             spaghetti
             with meatballs
-            # keep-sorted end
+            # keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testIgnorePrefixes() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start ignore_prefixes=fs.setBoolFlag,fs.setIntFlag
+            // keep-sorted-test start ignore_prefixes=fs.setBoolFlag,fs.setIntFlag
             fs.setBoolFlag("paws_with_cute_toebeans", true)
             fs.setBoolFlag("whiskered_adorable_dog", true)
             fs.setIntFlag("pretty_whiskered_kitten", 6)
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start ignore_prefixes=fs.setBoolFlag,fs.setIntFlag
+            // keep-sorted-test start ignore_prefixes=fs.setBoolFlag,fs.setIntFlag
             fs.setBoolFlag("paws_with_cute_toebeans", true)
             fs.setIntFlag("pretty_whiskered_kitten", 6)
             fs.setBoolFlag("whiskered_adorable_dog", true)
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testTrailingCommas() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start
+            // keep-sorted-test start
             c,
             b,
             a
-            // keep-sorted end
+            // keep-sorted-test end
+            // keep-sorted-test start
+            ".java",
+
+            ".yml",
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start
+            // keep-sorted-test start
             a,
             b,
             c
-            // keep-sorted end
+            // keep-sorted-test end
+            // keep-sorted-test start
+            ".java",
+            ".yml",
+            // keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testPrefixOrder() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start prefix_order=INIT_,,FINAL_
+            // keep-sorted-test start prefix_order=INIT_,,FINAL_
             DO_SOMETHING_WITH_BAR
             DO_SOMETHING_WITH_FOO
             FINAL_BAR
             FINAL_FOO
             INIT_BAR
             INIT_FOO
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start prefix_order=INIT_,,FINAL_
+            // keep-sorted-test start prefix_order=INIT_,,FINAL_
             INIT_BAR
             INIT_FOO
             DO_SOMETHING_WITH_BAR
             DO_SOMETHING_WITH_FOO
             FINAL_BAR
             FINAL_FOO
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testByRegex() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start by_regex=\w+;
+            // keep-sorted-test start by_regex=\w+;
             List<String> foo;
             Object baz;
             String bar;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start by_regex=\w+;
+            // keep-sorted-test start by_regex=\w+;
             String bar;
             Object baz;
             List<String> foo;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start by_regex=\w+; prefix_order=foo
+            // keep-sorted-test start by_regex=\w+; prefix_order=foo
             List<String> foo;
             Object baz;
             String bar;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start by_regex=\w+; prefix_order=foo
+            // keep-sorted-test start by_regex=\w+; prefix_order=foo
             List<String> foo;
             String bar;
             Object baz;
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
     }
 
     @Test
     fun testNumeric() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start numeric=yes
+            // keep-sorted-test start numeric=yes
             FOO_100
             FOO_2
             FOO_3
@@ -560,10 +569,10 @@ class KeepSortedTest {
             BAR_10
             BAR_00000000000000000000000000000000000000000000009
             BAR_99999999999999999999999999999999999999999999999
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start numeric=yes
+            // keep-sorted-test start numeric=yes
             BAR_1
             BAR_2
             BAR_00000000000000000000000000000000000000000000009
@@ -572,14 +581,14 @@ class KeepSortedTest {
             FOO_2
             FOO_3
             FOO_100
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
             deployment_state = [
-              // keep-sorted start numeric=yes prefix_order=INIT,ROLLOUT,COMPLETE
+              // keep-sorted-test start numeric=yes prefix_order=INIT,ROLLOUT,COMPLETE
               // All done.
               COMPLETE,
               // Start initialisation
@@ -595,12 +604,12 @@ class KeepSortedTest {
               ROLLOUT_10,
               ROLLOUT_5,
               ROLLOUT_50,
-              // keep-sorted end
+              // keep-sorted-test end
             ]
             """.trimIndent(),
             """
             deployment_state = [
-              // keep-sorted start numeric=yes prefix_order=INIT,ROLLOUT,COMPLETE
+              // keep-sorted-test start numeric=yes prefix_order=INIT,ROLLOUT,COMPLETE
               // Start initialisation
               INIT_1,
               INIT_5,
@@ -616,7 +625,7 @@ class KeepSortedTest {
               ROLLOUT_100,
               // All done.
               COMPLETE,
-              // keep-sorted end
+              // keep-sorted-test end
             ]
             """.trimIndent()
         )
@@ -624,7 +633,7 @@ class KeepSortedTest {
             config,
             """
             droid_components = [
-              // keep-sorted start numeric=yes prefix_order=R2,C3
+              // keep-sorted-test start numeric=yes prefix_order=R2,C3
               C3PO_HEAD,
               C3PO_ARM_L,
               R4_MOTIVATOR,
@@ -632,12 +641,12 @@ class KeepSortedTest {
               R2D2_BOLTS_10_MM,
               R2D2_PROJECTOR,
               R2D2_BOLTS_5_MM,
-              // keep-sorted end
+              // keep-sorted-test end
             ]
             """.trimIndent(),
             """
             droid_components = [
-              // keep-sorted start numeric=yes prefix_order=R2,C3
+              // keep-sorted-test start numeric=yes prefix_order=R2,C3
               R2D2_BOLTS_5_MM,
               R2D2_BOLTS_10_MM,
               R2D2_PROJECTOR,
@@ -645,7 +654,7 @@ class KeepSortedTest {
               C3PO_ARM_R,
               C3PO_HEAD,
               R4_MOTIVATOR,
-              // keep-sorted end
+              // keep-sorted-test end
             ]
             """.trimIndent()
         )
@@ -653,11 +662,11 @@ class KeepSortedTest {
 
     @Test
     fun testMaintainSuffix() {
-        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("kt"))
+        val config = KeepSortedConfig(matchRegexp = KeepSortedConfig.pattern("test"))
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
+            // keep-sorted-test start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
             C, // bob
             C, /* haha */
             1,
@@ -667,10 +676,10 @@ class KeepSortedTest {
             B, // lol
             1,
             A
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
+            // keep-sorted-test start maintain_suffix_order=(,)?(\s*(?://.*?|\/\*.*?|))
             1,
             A,
             B,
@@ -679,34 +688,34 @@ class KeepSortedTest {
             C, // bob
             D
               D // :)
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
         keepSorted.checkSorted(
             config,
             """
-            // keep-sorted start
+            // keep-sorted-test start
             1,
             3, // three
             2
-            // keep-sorted end
-            // keep-sorted start
+            // keep-sorted-test end
+            // keep-sorted-test start
             1,
             3,
             2 // two
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent(),
             """
-            // keep-sorted start
+            // keep-sorted-test start
             1,
             2
             3, // three
-            // keep-sorted end
-            // keep-sorted start
+            // keep-sorted-test end
+            // keep-sorted-test start
             1,
             2 // two,
             3
-            // keep-sorted end
+            // keep-sorted-test end
             """.trimIndent()
         )
     }


### PR DESCRIPTION
This will allow us to more efficiently handle two new modes in the future:

- Webhook/remote checker service
- File linter/fixer without any changelist
- Integrates KeepSorted as a checker