### PR TITLE
feat: Add keep-sorted templates to config

### DIFF
--- a/.github/presubmitchecks.json
+++ b/.github/presubmitchecks.json
@@ -61,7 +61,7 @@
         },
         {
           "id": "NoTrailingWhitespace",
-          "message": "Use spaces to indent, not tabs.",
+          "message": "Trailing whitespace is not allowed.",
           "severity": "WARNING",
           "matches": {
             "patterns": [
@@ -78,7 +78,10 @@
       "severity": "WARNING"
     },
     "KeepSorted": {
-      "severity": "ERROR"
+      "severity": "ERROR",
+      "templates": {
+        "gradle-dependencies": "block=yes case=no by_regex=(api|implementation|testImplementation)\"?\\([^)]\\) numeric=yes prefix_order=api,implementation,testImplementation,androidTestImplementation"
+      }
     },
     "NewLine": {
       "severity": "ERROR"

--- a/presubmitchecks-cli/build.gradle.kts
+++ b/presubmitchecks-cli/build.gradle.kts
@@ -4,13 +4,17 @@ plugins {
 }
 
 dependencies {
+    // keep-sorted start template=gradle-dependencies
     implementation(project(":presubmitchecks-core"))
+    // keep-sorted end
 
+    // keep-sorted start template=gradle-dependencies
     implementation(libs.clikt)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.kotlinx.serialization)
+    // keep-sorted end
 }
 
 application {

--- a/presubmitchecks-core/build.gradle.kts
+++ b/presubmitchecks-core/build.gradle.kts
@@ -4,8 +4,10 @@ plugins {
 }
 
 dependencies {
+    // keep-sorted start template=gradle-dependencies
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.re2j)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.strikt)
+    // keep-sorted end
 }


### PR DESCRIPTION
Supports configuring templates for keepsorted in the config file and uses it for sorting gradle dependencies.